### PR TITLE
Fix RangeRangeOverlaps typo

### DIFF
--- a/src/Macros/QueryBuilderMacros.php
+++ b/src/Macros/QueryBuilderMacros.php
@@ -13,7 +13,7 @@ class QueryBuilderMacros
         ['RangeDoesNotExtendToTheRightOf', '&<'],
         ['RangeAdjacentTo', '-|-'],
         ['RangeIsContainedBy', '<@'],
-        ['RangeRangeOverlaps', '&&'],
+        ['RangeOverlaps', '&&'],
         ['RangeStrictlyLeftOf', '<<'],
         ['RangeStrictlyRightOf', '>>'],
 


### PR DESCRIPTION
This PR fixes a typo in the query builder macro list which also brings it inline with docs `whereRangeOverlaps($left, $right)`