### PR TITLE
Add support for PHP 8.4 and update code accordingly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.3, 8.2, 8.1, 8.0, 7.4 ]
+        php: [ 8.4, 8.3, 8.2, 8.1, 8.0, 7.4 ]
         laravel: [ 11.*, 10.*, 9.*, 8.*, 7.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         exclude:
@@ -47,11 +47,15 @@ jobs:
             dependency-version: prefer-lowest
           - php: 8.3
             dependency-version: prefer-lowest
+          - php: 8.4
+            dependency-version: prefer-lowest
           - php: 8.1
             laravel: 7.*
           - php: 8.2
             laravel: 7.*
           - php: 8.3
+            laravel: 7.*
+          - php: 8.4
             laravel: 7.*
           - php: 7.4
             laravel: 9.*
@@ -64,6 +68,12 @@ jobs:
           - php: 8.0
             laravel: 11.*
           - php: 8.1
+            laravel: 11.*
+          - php: 8.2
+            laravel: 11.*
+          - php: 8.3
+            laravel: 11.*
+          - php: 8.4
             laravel: 11.*
         include:
           - laravel: 11.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,12 +57,6 @@ jobs:
             laravel: 7.*
           - php: 8.4
             laravel: 7.*
-          - php: 8.2
-            laravel: 8.*
-          - php: 8.3
-            laravel: 8.*
-          - php: 8.4
-            laravel: 8.*
           - php: 7.4
             laravel: 9.*
           - php: 7.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,12 @@ jobs:
             laravel: 7.*
           - php: 8.4
             laravel: 7.*
+          - php: 8.2
+            laravel: 8.*
+          - php: 8.3
+            laravel: 8.*
+          - php: 8.4
+            laravel: 8.*
           - php: 7.4
             laravel: 9.*
           - php: 7.4
@@ -68,12 +74,6 @@ jobs:
           - php: 8.0
             laravel: 11.*
           - php: 8.1
-            laravel: 11.*
-          - php: 8.2
-            laravel: 11.*
-          - php: 8.3
-            laravel: 11.*
-          - php: 8.4
             laravel: 11.*
         include:
           - laravel: 11.*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ vendor
 coverage
 .idea
 /.phpunit.result.cache
+/.phpunit.cache
 composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,47 @@ All notable changes to `postrges-range` will be documented in this file
 
 ## [Unreleased]
 
+## [1.2.3] - 2024-03-22
+
+### Added
+
+- Added support for PHP 8.4: [Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) [@isalcedo](https://github.com/isalcedo)
+
+## [1.2.2] - 2024-03-22
+
+### Added
+
+- Update laravel to v11 and other composer dependencies by [@Arthur-Sk](https://github.com/Arthur-Sk)
+
+## [1.2.1] - 2023-02-16
+
+### Added
+
+- added support for laravel 10
+
+## [1.2.0] - 2022-12-06
+
+### Added
+
+- added getters for boundaries by [@lunain84](https://github.com/lunain84)
+
+## [1.1.3] - 2022-02-08
+
+### Added
+
+- support for laravel 9
+
+## [1.1.2] - 2021-11-07
+
+### Added
+
+- updated github workflow strategy
+
 ## [1.1.1] - 2020-12-07
 
 ### Added
 
-- supprot for php 8
+- support for php 8
 
 ## [1.1.0] - 2020-09-26
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/belamov/postgres-range/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/belamov/postgres-range/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/belamov/postgres-range.svg?style=flat-square)](https://packagist.org/packages/belamov/postgres-range)
 
-This package provides support of PostgreSQL's range types for Laravel 7+.
+This package provides support for PostgreSQL's range types for Laravel 7+.
 
 Please check the [documentation](https://belamov.github.io/postgres-range)
 
 ### Changelog
 
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+Please see [CHANGELOG](CHANGELOG.md) for more information about what has changed recently.
 
 ## Contributing
 

--- a/src/Ranges/CanonicalRange.php
+++ b/src/Ranges/CanonicalRange.php
@@ -9,7 +9,7 @@ namespace Belamov\PostgresRange\Ranges;
  */
 abstract class CanonicalRange extends Range
 {
-    public function __construct(string $from = null, string $to = null, $fromBound = '[', $toBound = ')')
+    public function __construct(?string $from = null, ?string $to = null, string $fromBound = '[', string $toBound = ')')
     {
         parent::__construct($from, $to, $fromBound, $toBound);
         $this->canonicalizeBoundaries();

--- a/src/Ranges/Range.php
+++ b/src/Ranges/Range.php
@@ -9,7 +9,7 @@ abstract class Range
     protected ?string $from;
     protected ?string $to;
 
-    public function __construct(string $from = null, string $to = null, $fromBound = '[', $toBound = ')')
+    public function __construct(?string $from = null, ?string $to = null, string $fromBound = '[', string $toBound = ')')
     {
         $this->from = $from;
         $this->to = $to;


### PR DESCRIPTION
Hello :smile: 

This commit updates the GitHub workflow to include PHP 8.4 in the matrix and modifies constructor signatures in `CanonicalRange.php` and `Range.php` to handle nullability better, aligning with new PHP 8.4 standards. Additionally, minor corrections are made in `README.md` and `.gitignore` to improve clarity and ignore the new PHPUnit cache files.